### PR TITLE
Fix push success alert text

### DIFF
--- a/PushPush/Constants/StringConstants.swift
+++ b/PushPush/Constants/StringConstants.swift
@@ -8,7 +8,7 @@ import Foundation
 enum StringConstants {
     static let ok = "OK"
     static let chooseApnsFile = "Choose .apns file"
-    static let alertPushTitle = "Push sended"
+    static let alertPushTitle = "Push sent"
     static let alertPushErrorTitle = "Error while push sending"
     static let alertDeviceFetchErrorTitle = "Error while fetching devices"
     static let noDevicesError = "No devices found"


### PR DESCRIPTION
## Summary
- fix the push success message typo in `StringConstants`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f48ec2eb8832e95538a730e4972d6