### PR TITLE
Fix early exit on process run failure

### DIFF
--- a/PushPush/Model/XCRunHelper.swift
+++ b/PushPush/Model/XCRunHelper.swift
@@ -29,6 +29,7 @@ class XCRunHelper {
             try process.run()
         } catch {
             completion(.failure(XCRunError.processExecuteError))
+            return
         }
         
         let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
@@ -63,6 +64,7 @@ class XCRunHelper {
             try process.run()
         } catch {
             completion(.failure(XCRunError.processExecuteError))
+            return
         }
         
         let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()


### PR DESCRIPTION
## Summary
- ensure `avaliableSimulators` and `sendPushNotification` exit early when `Process.run()` fails

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f48f609e8832e993b7b9cc2cdce34