### PR TITLE
Fix asynchronous processes

### DIFF
--- a/PushPush/Model/XCRunHelper.swift
+++ b/PushPush/Model/XCRunHelper.swift
@@ -14,33 +14,32 @@ enum XCRunError: Error {
 class XCRunHelper {
     private let executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
     
-    func avaliableSimulators(_ completion: @escaping (Result<DevicesCollection, Error>) -> Void)  {
+    func availableSimulators(_ completion: @escaping (Result<DevicesCollection, Error>) -> Void)  {
         let process = Process()
         process.executableURL = executableURL
         process.arguments = ["simctl","list", "--json"]
-        
+
         let outputPipe = Pipe()
         let errorPipe = Pipe()
-        
+
         process.standardOutput = outputPipe
         process.standardError = errorPipe
-        
+
+        process.terminationHandler = { _ in
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+
+            guard let devicesCollection = try? JSONDecoder().decode(DevicesCollection.self, from: outputData) else {
+                completion(.failure(XCRunError.devicesListFetchError(errorData)))
+                return
+            }
+            completion(.success(devicesCollection))
+        }
+
         do {
             try process.run()
         } catch {
             completion(.failure(XCRunError.processExecuteError))
-        }
-        
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-        
-        
-        process.terminationHandler = { _ in
-            guard let devicesColletion = try? JSONDecoder().decode(DevicesCollection.self, from: outputData) else {
-                completion(.failure(XCRunError.devicesListFetchError(errorData)))
-                return
-            }
-            completion(.success(devicesColletion))
         }
     }
     
@@ -50,26 +49,33 @@ class XCRunHelper {
                               completion: @escaping (Result<String, XCRunError>) -> Void) {
         let process = Process()
         process.executableURL = executableURL
-        
+
         process.arguments = ["simctl", "push", udid, bundleId, filePath]
-        
+
         let outputPipe = Pipe()
         let errorPipe = Pipe()
-        
+
         process.standardOutput = outputPipe
         process.standardError = errorPipe
-        
+
+        process.terminationHandler = { _ in
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+
+            if !errorData.isEmpty {
+                let errorString = String(decoding: errorData, as: UTF8.self)
+                completion(.failure(XCRunError.pushSendError(errorString)))
+                return
+            }
+
+            let output = String(decoding: outputData, as: UTF8.self)
+            completion(.success(output))
+        }
+
         do {
             try process.run()
         } catch {
             completion(.failure(XCRunError.processExecuteError))
-        }
-        
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(decoding: outputData, as: UTF8.self)
-        
-        process.terminationHandler = { _ in
-            completion(.success(output))
         }
     }
 }

--- a/PushPush/View/ViewController.swift
+++ b/PushPush/View/ViewController.swift
@@ -84,7 +84,7 @@ private extension ViewController {
         // Clean previous devices
         simulatorSelectionPopUpButton.removeAllItems()
         
-        xcRunHelper.avaliableSimulators { [weak self] (result) in
+        xcRunHelper.availableSimulators { [weak self] (result) in
             switch result {
             case .failure(let error):
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1 , execute: {


### PR DESCRIPTION
## Summary
- fixed asynchronous calls in `XCRunHelper` so the main thread doesn't block
- propagate updated method name to `ViewController`

## Testing
- `swiftc -parse PushPush/Model/XCRunHelper.swift`
- `swiftc -parse PushPush/View/ViewController.swift`
- `swiftc PushPush/Model/*.swift -emit-library -o /tmp/dummy.dylib`


------
https://chatgpt.com/codex/tasks/task_e_683f47fc508c832ea944fbca57ead422